### PR TITLE
print elements of arrays in ahelp

### DIFF
--- a/esutil/numpy_util.py
+++ b/esutil/numpy_util.py
@@ -348,13 +348,16 @@ def _get_field_info(array, nspace=2, recurse=False, pretty=True, index=0):
                 d=''
                 hasfields=True
             else:
-                d = 'array[%s]' % shape_str
-                d = "["
-                for v in fdata.ravel():
-                    d += str(v)
-                    d += ", "
-                d = d[0:-2]
-                d += "]"
+                if len(fdata.shape) < 2 and fdata.size < 10:
+                    d = "["
+                    for v in fdata.ravel():
+                        d += str(v)
+                        d += ", "
+                    d = d[0:-2]
+                    d += "]"
+                    #d = fdata.__str__()
+                else:
+                    d = 'array[%s]' % shape_str
 
         if pretty and len(n) > 15:
             l = pformat % (n,type,d)

--- a/esutil/numpy_util.py
+++ b/esutil/numpy_util.py
@@ -349,6 +349,12 @@ def _get_field_info(array, nspace=2, recurse=False, pretty=True, index=0):
                 hasfields=True
             else:
                 d = 'array[%s]' % shape_str
+                d = "["
+                for v in fdata.ravel():
+                    d += str(v)
+                    d += ", "
+                d = d[0:-2]
+                d += "]"
 
         if pretty and len(n) > 15:
             l = pformat % (n,type,d)


### PR DESCRIPTION
This PR prints a limited number of elements of arrays when using `ahelp`. This is incredibly useful. 