### PR TITLE
avoid undefined behavior in init_numpy().

### DIFF
--- a/esutil/htm/htmc.cc
+++ b/esutil/htm/htmc.cc
@@ -9,11 +9,14 @@
 
 #if PY_MAJOR_VERSION >= 3
 static int *init_numpy(void) {
+    import_array();
+    return NULL;
+}
 #else
 static void init_numpy(void) {
-#endif
-	import_array();
+    import_array();
 }
+#endif
 
 
 // A couple of utility functions

--- a/esutil/include/NumpyRecords.h
+++ b/esutil/include/NumpyRecords.h
@@ -210,11 +210,14 @@
 
 #if PY_MAJOR_VERSION >= 3
 static int *init_numpy(void) {
+    import_array();
+    return NULL;
+}
 #else
 static void init_numpy(void) {
-#endif
-	import_array();
+    import_array();
 }
+#endif
 
 
 class NumpyRecords {

--- a/esutil/include/NumpyVector.h
+++ b/esutil/include/NumpyVector.h
@@ -267,11 +267,14 @@ std::map<const char*,int> NumpyVector<T>::mNumpyIdMap;
 
 #if PY_MAJOR_VERSION >= 3
 static int *init_numpy(void) {
+    import_array();
+    return NULL;
+}
 #else
 static void init_numpy(void) {
-#endif
-	import_array();
+    import_array();
 }
+#endif
 
 
 template <class T>

--- a/esutil/include/NumpyVoidVector.h
+++ b/esutil/include/NumpyVoidVector.h
@@ -101,11 +101,14 @@
 
 #if PY_MAJOR_VERSION >= 3
 static int *init_numpy(void) {
+    import_array();
+    return NULL;
+}
 #else
 static void init_numpy(void) {
-#endif
-	import_array();
+    import_array();
 }
+#endif
 
 
 class NumpyVoidVector {

--- a/esutil/recfile/records.cpp
+++ b/esutil/recfile/records.cpp
@@ -9,11 +9,14 @@
 
 #if PY_MAJOR_VERSION >= 3
 static int *init_numpy(void) {
+    import_array();
+    return NULL;
+}
 #else
 static void init_numpy(void) {
-#endif
-	import_array();
+    import_array();
 }
+#endif
 
 // check unicode for python3, string for python2
 static int is_python_string(const PyObject* obj)


### PR DESCRIPTION
Returning from a function without a return statement causes
an undefined behavior, which g++-8 makes use of for optimization,
resulting in a chaotic error.