### PR TITLE
pass tmpname string instead of tmpf.file file

### DIFF
--- a/esutil/sqlite_util.py
+++ b/esutil/sqlite_util.py
@@ -573,7 +573,7 @@ class SqliteConnection(sqlite.Connection):
         if self.verbose:
             stdout.write("Writing to temporary file: %s\n" % tmpname)
         # padding nulls since sqlite cannot deal with them
-        r = recfile.Open(tmpf.file,mode='w',delim='\t', padnull=True)
+        r = recfile.Open(tmpname,mode='w',delim='\t', padnull=True)
         r.write(data)
         r.close()
         tmpf.close()


### PR DESCRIPTION
I'm using esutil (on Python 2.7) to take a numpy structured array and write it to SQLite. I get the following error:

```
Traceback (most recent call last):
  File "./merge_messy.py", line 86, in <module>
    sc.array2table(messy,"messy",create=True)
  File "/usr/lib64/python2.7/site-packages/esutil/sqlite_util.py", line 521, in array2table
    tmpname = self.write_import_file(arr, extra=tablename)
  File "/usr/lib64/python2.7/site-packages/esutil/sqlite_util.py", line 576, in write_import_file
    r = recfile.Open(tmpf.file,mode='w',delim='\t', padnull=True)
  File "/usr/lib64/python2.7/site-packages/esutil/recfile/Util.py", line 53, in Open
    return Recfile(filename, mode=mode, **keys)
  File "/usr/lib64/python2.7/site-packages/esutil/recfile/Util.py", line 157, in __init__
    self.open(filename, mode=mode, **keys)
  File "/usr/lib64/python2.7/site-packages/esutil/recfile/Util.py", line 199, in open
    filename = os.path.expanduser(filename)
  File "/usr/lib64/python2.7/posixpath.py", line 261, in expanduser
    if not path.startswith('~'):
AttributeError: 'file' object has no attribute 'startswith'

```

The problem seems to be that recfile.Open expects a string, but is being given a file object. With my suggested change, my code works.