### PR TITLE
REF switch to string for ordering

### DIFF
--- a/esutil/wcsutil.py
+++ b/esutil/wcsutil.py
@@ -1198,8 +1198,8 @@ def make_xy_grid(n, xrang, yrang):
 
     x= numpy.outer(x, ones)
     y= numpy.outer(ones, y)
-    x = x.flatten(1)
-    y = y.flatten(1)
+    x = x.flatten('F')
+    y = y.flatten('F')
 
     return x,y
 


### PR DESCRIPTION
This pr closes #37.

I tested it locally. `'F'` is the right value.

```
In [1]: x = np.arange(5)                                                                                                                                                                                

In [2]: ones = np.ones(5)                                                                                                                                                                               

In [3]: np.outer(x, ones)                                                                                                                                                                               
Out[3]: 
array([[0., 0., 0., 0., 0.],
       [1., 1., 1., 1., 1.],
       [2., 2., 2., 2., 2.],
       [3., 3., 3., 3., 3.],
       [4., 4., 4., 4., 4.]])

In [4]: np.outer(x, ones).flatten(1)                                                                                                                                                                    
/Users/Matt/miniconda3/envs/anl/bin/ipython:1: DeprecationWarning: Non-string object detected for the array ordering. Please pass in 'C', 'F', 'A', or 'K' instead
  #!/Users/Matt/miniconda3/envs/anl/bin/python
Out[4]: 
array([0., 1., 2., 3., 4., 0., 1., 2., 3., 4., 0., 1., 2., 3., 4., 0., 1.,
       2., 3., 4., 0., 1., 2., 3., 4.])

In [5]: np.outer(x, ones).flatten('C')                                                                                                                                                                  
Out[5]: 
array([0., 0., 0., 0., 0., 1., 1., 1., 1., 1., 2., 2., 2., 2., 2., 3., 3.,
       3., 3., 3., 4., 4., 4., 4., 4.])

In [6]: np.outer(x, ones).flatten('F')                                                                                                                                                                  
Out[6]: 
array([0., 1., 2., 3., 4., 0., 1., 2., 3., 4., 0., 1., 2., 3., 4., 0., 1.,
       2., 3., 4., 0., 1., 2., 3., 4.])
```