### PR TITLE
Updating setup.py for better macOS support.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,8 @@ except:
     time.sleep(5)
 
 if platform.system()=='Darwin':
-    extra_compile_args=['-arch','i386','-arch','x86_64']
-    extra_link_args=['-arch','i386','-arch','x86_64']
+    extra_compile_args = ['-stdlib=libc++']
+    extra_link_args=[]
 else:
     extra_compile_args=[]
     extra_link_args=[]


### PR DESCRIPTION
Removed flags for building code for i386 architechture. The compiler will do the right thing without specifying this, and 32-bit code support will be removed in 10.15 altogether anyway (deprecated since 10.13). Adding the flag '-stdlib=libc++' required to build on macOS.