### PR TITLE
Added pickle support for `Cosmo` objects

### DIFF
--- a/esutil/cosmology/cosmology.py
+++ b/esutil/cosmology/cosmology.py
@@ -134,7 +134,7 @@ class Cosmo(object):
 
     @property
     def _pars(self):
-        return self.H0(), None, bool(self.flat), self.omega_m(), self.omega_l(), self.omega_k()
+        return self.H0(), None, bool(self.flat()), self.omega_m(), self.omega_l(), self.omega_k()
 
     def Dc(self, zmin, zmax):
         """

--- a/esutil/cosmology/cosmology.py
+++ b/esutil/cosmology/cosmology.py
@@ -115,6 +115,9 @@ class Cosmo(object):
 
         self._H0 = H0
 
+    def __reduce__(self):
+        return (self.__class__, (self._pars))
+
     def H0(self):
         return copy.deepcopy(self._H0)
 
@@ -128,6 +131,10 @@ class Cosmo(object):
         return self._cosmo.omega_l()
     def omega_k(self):
         return self._cosmo.omega_k()
+
+    @property
+    def _pars(self):
+        return self.H0(), None, bool(self.flat), self.omega_m(), self.omega_l(), self.omega_k()
 
     def Dc(self, zmin, zmax):
         """

--- a/esutil/unit_tests/__init__.py
+++ b/esutil/unit_tests/__init__.py
@@ -2,9 +2,11 @@ from . import sfile_tests
 from . import htm_tests
 from . import hist_tests
 from . import int_tests
+from . import pickle_tests
 
 def test():
     sfile_tests.test()
     htm_tests.test()
     hist_tests.test()
     int_tests.test()
+    pickle_tests.test()

--- a/esutil/unit_tests/pickle_tests.py
+++ b/esutil/unit_tests/pickle_tests.py
@@ -25,6 +25,7 @@ class TestPickleCosmo(unittest.TestCase):
             with open(fn, 'rb') as f:
                 _cosmo = pickle.load(f)
 
+            self.assertEqual(cosmo.H0(), _cosmo.H0())
             self.assertEqual(cosmo.DH(), _cosmo.DH())
             self.assertEqual(cosmo.flat(), _cosmo.flat())
             self.assertEqual(cosmo.omega_m(), _cosmo.omega_m())

--- a/esutil/unit_tests/pickle_tests.py
+++ b/esutil/unit_tests/pickle_tests.py
@@ -1,0 +1,56 @@
+from __future__ import with_statement, print_function
+import sys, os
+import tempfile
+import warnings
+
+from ..cosmology import Cosmo
+import tempfile
+import pickle
+
+import unittest
+
+
+def test():
+    suite = unittest.TestLoader().loadTestsFromTestCase(TestPickleCosmo)
+    unittest.TextTestRunner(verbosity=2).run(suite)
+
+
+class TestPickleCosmo(unittest.TestCase):
+
+    def _pickle_compare(self, cosmo):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            fn = os.path.join(temp_dir, 'cosmo.pkl')
+            with open(fn, 'wb') as f:
+                pickle.dump(cosmo, f)
+            with open(fn, 'rb') as f:
+                _cosmo = pickle.load(f)
+
+            self.assertEqual(cosmo.DH(), _cosmo.DH())
+            self.assertEqual(cosmo.flat(), _cosmo.flat())
+            self.assertEqual(cosmo.omega_m(), _cosmo.omega_m())
+            self.assertEqual(cosmo.omega_l(), _cosmo.omega_l())
+            self.assertEqual(cosmo.omega_k(), _cosmo.omega_k())
+
+    def test_pickle_compare1(self):
+        """
+        Test case 1
+        """
+        cosmo = Cosmo(h=None, H0=0.7, flat=True, omega_m=0.27, omega_l=0.73,
+                      omega_k=0.0)
+        self._pickle_compare(cosmo=cosmo)
+
+    def test_pickle_compare2(self):
+        """
+        Test case 2
+        """
+        cosmo = Cosmo(h=None, H0=0.67, flat=False, omega_m=0.32, omega_l=0.67,
+                      omega_k=0.01)
+        self._pickle_compare(cosmo=cosmo)
+
+    def test_pickle_compare3(self):
+        """
+        Test case 3
+        """
+        cosmo = Cosmo(h=1, H0=None, flat=None, omega_m=0.3, omega_l=0.7,
+                      omega_k=None)
+        self._pickle_compare(cosmo=cosmo)


### PR DESCRIPTION
`_cosmolib` (and therefore `Cosmo`) objects are not easily pickled. Adding a __reduce__ method to recreate the `Cosmo` object upon pickling resolves this issue and maintains all attributes from the underlying `_cosmolib` object. All unit tests pass.