### PR TITLE
Check if Mac needs -stdlib=libc++ and only add if needed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,12 @@ import time
 from sys import stdout,stderr
 from glob import glob
 import platform
+import tempfile
+import subprocess
+import shutil
 
 from distutils.core import setup,Extension
+from distutils.command.build_ext import build_ext
 
 import distutils.sysconfig
 import os
@@ -25,13 +29,128 @@ except:
     stdout.write('Numpy not found:  Not building C extensions\n')
     time.sleep(5)
 
-if platform.system()=='Darwin':
-    extra_compile_args = ['-stdlib=libc++']
-    extra_link_args=[]
-else:
-    extra_compile_args=[]
-    extra_link_args=[]
+extra_compile_args=[]
+extra_link_args=[]
 
+#
+# Figure out if we need to add any extra flags:
+#
+local_tmp = 'tmp'
+
+def try_compile(cpp_code, compiler, cflags=[], lflags=[]):
+    """Check if compiling some code with the given compiler and flags works properly.
+    """
+    # Put the temporary files in a local tmp directory, so that they stick around after failures.
+    if not os.path.exists(local_tmp): os.makedirs(local_tmp)
+
+    # We delete these manually if successful.  Otherwise, we leave them in the tmp directory
+    # so the user can troubleshoot the problem if they were expecting it to work.
+    with tempfile.NamedTemporaryFile(delete=False, suffix='.cpp', dir=local_tmp) as cpp_file:
+        cpp_file.write(cpp_code.encode())
+        cpp_name = cpp_file.name
+
+    # Just get a named temporary file to write to:
+    with tempfile.NamedTemporaryFile(delete=False, suffix='.os', dir=local_tmp) as o_file:
+        o_name = o_file.name
+
+    # Another named temporary file for the executable
+    with tempfile.NamedTemporaryFile(delete=False, suffix='.exe', dir=local_tmp) as exe_file:
+        exe_name = exe_file.name
+
+    # Try compiling with the given flags
+    cc = [compiler.compiler_so[0]]
+    cmd = cc + compiler.compiler_so[1:] + cflags + ['-c',cpp_name,'-o',o_name]
+    try:
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        lines = p.stdout.readlines()
+        p.communicate()
+        if p.returncode != 0:
+            # Print the error if there was one, to help the user diagnose the problem.
+            print('Trying compile command:')
+            print(' '.join(cmd))
+            print('Output was:')
+            print('   ',b'   '.join(lines).decode())
+        returncode = p.returncode
+    except (IOError,OSError) as e:
+        print('Trying compile command:')
+        print(cmd)
+        print('Caught error: ',repr(e))
+        returncode = 1
+    if returncode != 0:
+        # Don't delete files in case helpful for troubleshooting.
+        return False
+
+    # Link
+    cc = compiler.linker_so[0]
+    cmd = [cc] + compiler.linker_so[1:] + lflags + [o_name,'-o',exe_name]
+    try:
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        lines = p.stdout.readlines()
+        p.communicate()
+        if p.returncode != 0:
+            print('Trying link command:')
+            print(' '.join(cmd))
+            print('Output was:')
+            print('   ',b'   '.join(lines).decode())
+        returncode = p.returncode
+    except (IOError,OSError) as e:
+        print('Trying link command:')
+        print(' '.join(cmd))
+        print('Caught error: ',repr(e))
+        returncode = 1
+
+    return returncode == 0
+
+def check_flags(compiler):
+    """Check if we need to adjust the standard cflags for specific systems
+    """
+    # Start with a canonical set of flags to use
+    cflags = extra_compile_args
+    lflags = extra_link_args
+
+    if platform.system()=='Darwin':
+        # Usually Macs need this, but they might not, so try it, and only add if it works.
+        cflags1 = cflags + ['-stdlib=libc++']
+        lflags1 = lflags + ['-stdlib=libc++']
+        cpp_code = r"""
+            #include <iostream>
+            int main() {
+                std::cout<<"Hello World\n";
+                return 0;
+            }
+            """
+        if try_compile(cpp_code, compiler, cflags1, lflags1):
+            # Success
+            print('Compilation succeeded with -stdlib=libc++.')
+            cflags = cflags1
+            lflags = lflags1
+        elif try_compile(cpp_code, compiler, cflags, lflags):
+            # Failed with stdlib, but success without
+            # Leave cflags, lflags as they are.
+            print('Compilation succeeded without -stdlib=libc++.')
+        else:
+            # Failed either way.  :(
+            print('Error: Unable to determine correct compile flags')
+            exit()
+
+    return cflags, lflags
+
+class my_builder(build_ext):
+    def build_extensions(self):
+        cflags, lflags = check_flags(self.compiler)
+
+        # Add the appropriate extra flags for that compiler.
+        for e in self.extensions:
+            e.extra_compile_args = cflags
+            for flag in lflags:
+                e.extra_link_args.append(flag)
+
+        # Now run the normal build function.
+        build_ext.build_extensions(self)
+
+#
+# Make the extensions to be built
+#
 
 if have_numpy:
     # recfile
@@ -157,5 +276,10 @@ setup(name='esutil',
       license = "GPL",
       url='http://code.google.com/p/esutil/',
       packages=packages,
+      cmdclass = {'build_ext': my_builder},
       ext_modules=ext_modules)
 #, install_requires=['numpy'])
+
+# If we get to here, then all was fine.  Go ahead and delete the files in the tmp directory.
+if os.path.exists(local_tmp):
+    shutil.rmtree(local_tmp)


### PR DESCRIPTION
There is an unfortunate amount of boiler-plate required to check if given compiler flags work.  But the framework is there if you want to test any other flags that might be needed or desirable on other systems now.