### PR TITLE
Change inverse computation to lazy-computation speeding up initialization

### DIFF
--- a/esutil/wcsutil.py
+++ b/esutil/wcsutil.py
@@ -137,7 +137,7 @@ class WCS(object):
     A class to do WCS transformations.  Currently supports TAN projections
     for 
 
-        RA--TPV, DEC-TPV
+        RA---TPV, DEC--TPV
         RA---TAN and DEC--TAN
         RA---TAN--SIP,DEC--TAN--SIP
 


### PR DESCRIPTION
The inverse isn't actually needed all the time, and this speeds up initialization by a factor of approximately x133.