### PR TITLE
Protect against any stomp problems on import

### DIFF
--- a/esutil/stomp_util.py
+++ b/esutil/stomp_util.py
@@ -4,16 +4,17 @@ from sys import stdout
 try:
     import stomp
 
-    have_stomp = True
-
     INSIDE_MAP = stomp.cvar.Map_INSIDE_MAP
     FIRST_QUADRANT_OK = stomp.cvar.Map_FIRST_QUADRANT_OK
     SECOND_QUADRANT_OK = stomp.cvar.Map_SECOND_QUADRANT_OK
     THIRD_QUADRANT_OK = stomp.cvar.Map_THIRD_QUADRANT_OK
     FOURTH_QUADRANT_OK = stomp.cvar.Map_FOURTH_QUADRANT_OK
 
-except ImportError:
+except Exception:
     have_stomp = False
+
+else:
+    have_stomp = True
 
 import numpy as np
 


### PR DESCRIPTION
The stomp import can succeed but the .cvar access can fail.
Protect against all failures with stomp on import and only
set have_stomp on success.

With conda-forge stomp.py installed with 0.6.7.2 esutil we are seeing the following:

```
>>> import esutil
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Volumes/MediaHD/Users/timj/work/lsstsw/miniconda/envs/lsst-scipipe-0.6.0/lib/python3.8/site-packages/esutil/__init__.py", line 118, in <module>
    from . import stomp_util
  File "/Volumes/MediaHD/Users/timj/work/lsstsw/miniconda/envs/lsst-scipipe-0.6.0/lib/python3.8/site-packages/esutil/stomp_util.py", line 9, in <module>
    INSIDE_MAP = stomp.cvar.Map_INSIDE_MAP
AttributeError: module 'stomp' has no attribute 'cvar'
```

0.6.5 worked because it caught all exceptions. This PR reverts to that broader catch.