### PR TITLE
A bit hacky way of forcing numpy to be installed 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,10 @@ import tempfile
 import subprocess
 import shutil
 
+# A bit hacky way to have numpy installed before continuing the script
+from setuptools import dist
+dist.Distribution().fetch_build_eggs(['numpy'])
+
 from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext
 


### PR DESCRIPTION
prior to main body of setup.py so that it may use numpy.get_include()

It seems there is no "official" way to do it - see e.g. https://stackoverflow.com/questions/54117786/add-numpy-get-include-argument-to-setuptools-without-preinstalled-numpy (the solution is borrowed from that thread)
