### PR TITLE
Check whether `-std=c++11` can be safely added to the compiler flags

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,10 +8,17 @@ jobs:
   tests:
     name: tests
     strategy:
+      fail-fast: false
       matrix:
+        os: [ubuntu-latest]
         pyver: [3.7, 3.8, 3.9]
+        compiler: [gcc]
+        include:
+            - os: macos-latest
+              pyver: 3.9
+              compiler: clang
 
-    runs-on: "ubuntu-latest"
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v2
@@ -22,6 +29,8 @@ jobs:
           python-version: ${{ matrix.pyver }}
 
       - name: Install code
+        env:
+            CC: ${{ matrix.compiler }}
         run: pip install -e .
 
       - name: lint

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ extra_link_args = []
 local_tmp = "tmp"
 
 
-def try_compile(cpp_code, compiler, cflags=[], lflags=[]):
+def try_compile(cpp_code, compiler, cflags=[], lflags=[], c_not_cpp=False):
     """
     Check if compiling some code with the given compiler and flags works
     properly.
@@ -40,7 +40,7 @@ def try_compile(cpp_code, compiler, cflags=[], lflags=[]):
     # tmp directory so the user can troubleshoot the problem if they were
     # expecting it to work.
     with tempfile.NamedTemporaryFile(
-        delete=False, suffix=".cpp", dir=local_tmp
+        delete=False, suffix=".c" if c_not_cpp else ".cpp" , dir=local_tmp
     ) as cpp_file:
         cpp_file.write(cpp_code.encode())
         cpp_name = cpp_file.name
@@ -83,6 +83,9 @@ def try_compile(cpp_code, compiler, cflags=[], lflags=[]):
         # Don't delete files in case helpful for troubleshooting.
         return False
 
+    if lflags == []:
+        return returncode == 0
+
     # Link
     cc = compiler.linker_so[0]
     cmd = [cc] + compiler.linker_so[1:] + lflags + [o_name, "-o", exe_name]
@@ -113,7 +116,10 @@ def check_flags(compiler):
     cflags = extra_compile_args
     lflags = extra_link_args
 
-    cflags += ["-std=c++11"]
+    # Check whether we can safely add -std=c++11
+    if try_compile("int main (int argc, char **argv) { return 0; }",
+                   compiler, ["-std=c++11"], [], c_not_cpp=True):
+        cflags += ["-std=c++11"]
 
     if platform.system() == "Darwin":
         # Usually Macs need this, but they might not, so try it, and only add


### PR DESCRIPTION
Pretty minimal fix to #78. I added a ``clang`` build to make sure this doesn't regress; this built fails without this fix. 

Note that you seem to have some linting errors that make the all Python 3.8 and 3.9 build fail, but these are unrelated to this PR I think. I also turned off `fail-fast` to make sure that all build jobs run, otherwise they terminate as soon as one fails. For tests, I generally prefer not to use `fail-fast` to see all possible failures in one go.